### PR TITLE
Steam Deploy only supports single MacOS binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ Assumptions
         configVdf:         ${{ secrets.STEAM_CONFIG_VDF }} # Saved Steam login session (see below)
         appId:             "xxxx"                          # your Steam Application ID
         windowsDepotId:    "xxxx"                          # the Steam Depot ID for your win32-x64 binaries (if any)
+        macosDepotId:      "xxxx"                          # the Steam Depot ID for your darwin-x64 binaries (if any)
         linuxDepotId:      "xxxx"                          # the Steam Depot ID for your linux-x64 binaries (if any)
-        appleIntelDepotId: "xxxx"                          # the Steam Depot ID for your darwin-x64 binaries (if any)
-        appleArmDepotId:   "xxxx"                          # the Steam Depot ID for your darwin-arm64 binaries (if any)
         buildDescription:  "latest beta test"              # (optional) build description
 ```
 

--- a/deploy/steam/action.yml
+++ b/deploy/steam/action.yml
@@ -22,14 +22,11 @@ inputs:
   windowsDepotId:
     description: "A Steam Depot ID to contain your Windows executable"
     required: false
+  macosDepotId:
+    description: "A Steam Depot ID to contain your MacOS excutable"
+    required: false
   linuxDepotId:
     description: "A Steam Depot ID to contain your Linux executable"
-    required: false
-  appleIntelDepotId:
-    description: "A Steam Depot ID to contain your Apple (Intel) excutable"
-    required: false
-  appleArmDepotId:
-    description: "A Steam Depot ID to contain your Apple (ARM) executable"
     required: false
   buildDescription:
     description: "Description for this build"
@@ -44,7 +41,6 @@ runs:
     configVdf: ${{ inputs.configVdf }}
     appId: ${{ inputs.appId }}
     windowsDepotId: ${{ inputs.windowsDepotId }}
+    macosDepotId: ${{ inputs.macosDepotId }}
     linuxDepotId: ${{ inputs.linuxDepotId }}
-    appleIntelDepotId: ${{ inputs.appleIntelDepotId }}
-    appleArmDepotId: ${{ inputs.appleArmDepotId }}
     buildDescription: ${{ inputs.buildDescription }}

--- a/deploy/steam/entrypoint.sh
+++ b/deploy/steam/entrypoint.sh
@@ -67,25 +67,10 @@ cat << EOF >> "$manifestFile"
 EOF
 fi
 
-if [[ ! -z "$linuxDepotId" ]]; then
-echo "... including linux depot"
-cat << EOF >> "$manifestFile"
-    "$linuxDepotId"
-    {
-      "FileMapping"
-      {
-        "LocalPath" "./$executable-linux-x64/*"
-        "DepotPath" "."
-        "recursive" "1"
-      }
-    }
-EOF
-fi
-
-if [[ ! -z "$appleIntelDepotId" ]]; then
+if [[ ! -z "$macosDepotId" ]]; then
 echo "... including apple (intel) depot"
 cat << EOF >> "$manifestFile"
-    "$appleIntelDepotId"
+    "$macosDepotId"
     {
       "FileMapping"
       {
@@ -97,14 +82,14 @@ cat << EOF >> "$manifestFile"
 EOF
 fi
 
-if [[ ! -z "$appleArmDepotId" ]]; then
-echo "... including apple (arm) depot"
+if [[ ! -z "$linuxDepotId" ]]; then
+echo "... including linux depot"
 cat << EOF >> "$manifestFile"
-    "$appleArmDepotId"
+    "$linuxDepotId"
     {
       "FileMapping"
       {
-        "LocalPath" "./$executable-darwin-arm64/*"
+        "LocalPath" "./$executable-linux-x64/*"
         "DepotPath" "."
         "recursive" "1"
       }


### PR DESCRIPTION
This PR simplifies the deploy/steam action to support only a single set of binaries for MacOS because Steam doesn't really have a way to deploy both x64 and arm64 binaries at this time

> Apparently Steam de-prioritizes Mac features (some founder grudge against apple), so currently you need to create a separate app ID if you want to distribute 2 separate mac binaries - ugh.