### PR TITLE
Add workflow to publish steam/login docker image

### DIFF
--- a/.github/workflows/publish-steam-login.yml
+++ b/.github/workflows/publish-steam-login.yml
@@ -1,0 +1,51 @@
+name: Publish Steam Login Docker Image
+on:
+  push:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: vaguevoid/steam/login
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          file: deploy/steam/login/Dockerfile
+          context: deploy/steam/login
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to publish the `vaguevoid/steam/login` docker image to the GitHub container registry (ghcr.io)