### PR TITLE
Allow steam branch to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This [action](share/on/steam/action.yml) can be used to build, package, and depl
         windowsDepotId:   "xxxx"                          # the Steam Depot ID for your Windows binaries
         macosDepotId:     "xxxx"                          # the Steam Depot ID for your MacOS binaries (if any)
         linuxDepotId:     "xxxx"                          # the Steam Depot ID for your Linux binaries (if any)
+        setLiveBranch:    "beta"                          # (optional) Steam branch to set live with this build (if any)
         buildDescription: "latest and greatest"           # (optional) build description
 ```
 

--- a/deploy/steam/action.yml
+++ b/deploy/steam/action.yml
@@ -2,45 +2,43 @@ name: "Void Deploy Steam"
 author: "Jake Gordon <jake@void.dev>"
 description: "Deploy Void game to Steam"
 inputs:
+  buildDescription:
+    description: "Description for this build"
+  executable:
+    description: "executable file name prefix (not including extension)"
+    default: "void"
   releasePath:
     description: "path to packaged releases"
     default: "release"
-    required: true
-  executable:
-    description: "executable name used when packaging game"
-    default: "electron"
-    required: true
   username:
-    description: "A Steam username"
+    description: "Steam username"
     required: true
   configVdf:
     description: "A steamcmd authorization config.vdf file (base64 encoded)"
     required: true
   appId:
-    description: "A Steam Application ID"
+    description: "Steam Application ID"
     required: true
   windowsDepotId:
-    description: "A Steam Depot ID to contain your Windows executable"
-    required: false
+    description: "Steam Depot ID for Windows binaries"
   macosDepotId:
-    description: "A Steam Depot ID to contain your MacOS excutable"
-    required: false
+    description: "Steam Depot ID for MacOS binaries"
   linuxDepotId:
-    description: "A Steam Depot ID to contain your Linux executable"
-    required: false
-  buildDescription:
-    description: "Description for this build"
-    required: false
+    description: "Steam Depot ID for Linux binaries"
+  setLiveBranch:
+    description: "A custom Steam branch to set live with this build ('default' not allowed)"
+
 runs:
   using: "docker"
   image: "Dockerfile"
   env:
-    releasePath: ${{ inputs.releasePath }}
+    buildDescription: ${{ inputs.buildDescription }}
     executable: ${{ inputs.executable }}
+    releasePath: ${{ inputs.releasePath }}
     username: ${{ inputs.username }}
     configVdf: ${{ inputs.configVdf }}
     appId: ${{ inputs.appId }}
     windowsDepotId: ${{ inputs.windowsDepotId }}
     macosDepotId: ${{ inputs.macosDepotId }}
     linuxDepotId: ${{ inputs.linuxDepotId }}
-    buildDescription: ${{ inputs.buildDescription }}
+    setLiveBranch: ${{ inputs.setLiveBranch }}

--- a/deploy/steam/entrypoint.sh
+++ b/deploy/steam/entrypoint.sh
@@ -48,6 +48,15 @@ cat << EOF > "$manifestFile"
   "Desc" "$buildDescription"
   "ContentRoot" "$releasePath"
   "BuildOutput" "$releasePath"
+EOF
+
+if [[ ! -z "$setLiveBranch" ]]; then
+cat << EOF >> "$manifestFile"
+  "SetLive" "$setLiveBranch"
+EOF
+fi
+
+cat << EOF >> "$manifestFile"
   "Depots"
   {
 EOF
@@ -68,7 +77,7 @@ EOF
 fi
 
 if [[ ! -z "$macosDepotId" ]]; then
-echo "... including apple (intel) depot"
+echo "... including macos depot"
 cat << EOF >> "$manifestFile"
     "$macosDepotId"
     {

--- a/deploy/steam/readme.md
+++ b/deploy/steam/readme.md
@@ -1,4 +1,4 @@
-# Deploy with Steam
+# Deploy to Steam
 
 This action can be used to deploy a Void game to Steam
 

--- a/deploy/steam/readme.md
+++ b/deploy/steam/readme.md
@@ -17,8 +17,9 @@ Assumptions
         username:          gordonja                        # Steam username
         configVdf:         ${{ secrets.STEAM_CONFIG_VDF }} # Saved Steam login session (see below)
         appId:             "xxxx"                          # your Steam Application ID
-        windowsDepotId:    "xxxx"                          # the Steam Depot ID for your win32-x64 binaries (if any)
-        macosDepotId:      "xxxx"                          # the Steam Depot ID for your darwin-x64 binaries (if any)
-        linuxDepotId:      "xxxx"                          # the Steam Depot ID for your linux-x64 binaries (if any)
-        buildDescription:  "latest beta test"              # (optional) build description
+        windowsDepotId:    "xxxx"                          # the Steam Depot ID for your win32-x64 binaries
+        macosDepotId:      "xxxx"                          # the Steam Depot ID for your darwin-x64 binaries (optional)
+        linuxDepotId:      "xxxx"                          # the Steam Depot ID for your linux-x64 binaries (optional)
+        setLiveBranch:     "beta"                          # the Steam branch to set live with this build (optional)
+        buildDescription:  "latest beta test"              # a build description (optional)
 ```

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -28,6 +28,8 @@ inputs:
     description: "Steam Depot ID for MacOS binaries"
   linuxDepotId:
     description: "Steam Depot ID for Linux binaries"
+  setLiveBranch:
+    description: "A custom Steam branch to set live with this build ('default' not allowed)"
 
 runs:
   using: "composite"
@@ -71,13 +73,14 @@ runs:
     - name: "Deploy"
       uses: "vaguevoid/actions/deploy/steam@alpha"
       with:
-        releasePath: ${{ inputs.releasePath }}
+        buildDescription: ${{ inputs.buildDescription }}
         executable: ${{ inputs.executable }}
+        releasePath: ${{ inputs.releasePath }}
         username: ${{ inputs.username }}
         configVdf: ${{ inputs.configVdf }}
         appId: ${{ inputs.appId }}
         windowsDepotId: ${{ inputs.windowsDepotId }}
         macosDepotId: ${{ inputs.macosDepotId }}
         linuxDepotId: ${{ inputs.linuxDepotId }}
-        buildDescription: ${{ inputs.buildDescription }}
+        setLiveBranch: ${{ inputs.setLiveBranch }}
 


### PR DESCRIPTION
This PR allows the steam branch to be specified using the `setLiveBranch` input to the `share/on/steam` action (passed through to the underlying `deploy/steam` action)