### PR TITLE
Include Node (in addition to Bun) in the build/vite action

### DIFF
--- a/build/vite/Dockerfile
+++ b/build/vite/Dockerfile
@@ -1,3 +1,4 @@
-From oven/bun:1.1
+FROM node:21
+RUN npm install -g bun@1.0.36
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR modifies the base docker image for the `vaguevoid/build/vite` action to include both NODE and BUN, since some game dependencies (e.g. vue-tsc) require Node to be present during the build phase.

So instead of using `oven/bun` as the base image, use `node:21` and then `run npm install bun` to get both.