### PR TITLE
Improved error message when upload fails with 404

### DIFF
--- a/deploy/web/entrypoint.sh
+++ b/deploy/web/entrypoint.sh
@@ -43,11 +43,18 @@ fi
 tar -czf ${bundle} -C ${path} .
 
 echo "Uploading ${bundle} to ${endpoint}"
-OUTPUT=$(curl -s -X POST --fail-with-body --connect-timeout 180 --max-time 180 -H "X-Deploy-Password: ${password}" -H "Authorization: Bearer ${token}" --data-binary "@${bundle}" ${endpoint})
-if [ $? -ne 0 ]; then
-  echo $OUTPUT
+OUTPUT_FILE=$(mktemp)
+STATUS_CODE=$(curl -s -X POST -o $OUTPUT_FILE -w "%{http_code}" --connect-timeout 180 --max-time 180 -H "X-Deploy-Password: ${password}" -H "Authorization: Bearer ${token}" --data-binary "@${bundle}" ${endpoint} 2>/dev/null)
+
+if [[ $STATUS_CODE == "404" ]]; then
+  echo "endpoint ${endpoint} not found, are the organization and game correct?"
+  exit 1
+fi
+
+if [[ $STATUS_CODE != "200" ]]; then
+  echo "STATUS: $STATUS_CODE"
   echo "Sorry, upload failed, please try again in a few minutes or contact support@void.dev"
   exit 1
 fi
 
-echo $OUTPUT
+cat $OUTPUT_FILE


### PR DESCRIPTION
Resolve issue #9 

This PR improves the deploy/web action to inspect the http response code from the curl command and display a more appropriate error message. If it's a 404 because the organization or game name are not found (or unauthorized - we use 404 in both cases) then display a more friendly message
