### PR TITLE
Add texture compression to share/on/steam

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This [action](share/on/steam/action.yml) can be used to build, package, and depl
         linuxDepotId:     "xxxx"                          # the Steam Depot ID for your Linux binaries (optional)
         setLiveBranch:    "beta"                          # the Steam branch to set live with this build (optional)
         buildDescription: "latest and greatest"           # a build description (optional)
-        pngCompressor:    "-d assets -i favicon.ico"      # arguments for png_compressor (optional)
+        pngCompressor:    "-d release/web -i favicon.png" # arguments for png_compressor (optional)
 ```
 
 For actions that deploy to steam you will need to provide the contents of a Steam `config.vdf`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This [action](share/on/steam/action.yml) can be used to build, package, and depl
         linuxDepotId:     "xxxx"                          # the Steam Depot ID for your Linux binaries (optional)
         setLiveBranch:    "beta"                          # the Steam branch to set live with this build (optional)
         buildDescription: "latest and greatest"           # a build description (optional)
+        pngCompressor:    "-d assets -i favicon.ico"      # arguments for png_compressor (optional)
 ```
 
 For actions that deploy to steam you will need to provide the contents of a Steam `config.vdf`
@@ -67,6 +68,7 @@ you can drop down to the lower level actions below and combine them to build you
 own workflow steps:
 
   * [Build with Vite](build/vite/readme.md) - Build for the web using Vite
+  * [Build - Compress Textures](build/png_compressor/action.yml) - Compress .png images to optimized .dxt textures
   * [Package with Electron](package/electron/readme.md) - Package existing web build using Electron
   * [Deploy to Web](deploy/web/readme.md) - Deploy existing built game to the Web at https://play.void.dev
   * [Deploy to Steam](deploy/steam/readme.md) - Deploy existing packaged game to Steam

--- a/build/png_compressor/action.yml
+++ b/build/png_compressor/action.yml
@@ -1,0 +1,12 @@
+name: "Void Png Compressor"
+author: "Jake Gordon <jake@void.dev>"
+description: "Compress .png textures to WebGPU optimized .dxt format"
+inputs:
+  args:
+    description: "arguments to png_compressor (-d /path/to/assets -i ignore.png")
+    required: true
+runs:
+  using: "docker"
+  image: "docker://vaguevoid/png_compressor:latest"
+  args:
+    - ${{ inputs.args }}

--- a/build/vite/action.yml
+++ b/build/vite/action.yml
@@ -8,9 +8,14 @@ inputs:
   baseUrl:
     description: "base URL"
     default: "./"
+  deployTarget:
+    description: "(optional) set VITE_DEPLOY_TARGET if you require conditional code based on import.meta.env.VITE_DEPLOY_TARGET"
+    required: false
+    default: "web"
 runs:
   using: "docker"
   image: "Dockerfile"
   env:
     output: ${{ inputs.output }}
     baseUrl: ${{ inputs.baseUrl }}
+    VITE_DEPLOY_TARGET: ${{ inputs.deployTarget }}

--- a/build/vite/action.yml
+++ b/build/vite/action.yml
@@ -18,4 +18,4 @@ runs:
   env:
     output: ${{ inputs.output }}
     baseUrl: ${{ inputs.baseUrl }}
-    VITE_DEPLOY_TARGET: ${{ inputs.deployTarget }}
+    deployTarget: ${{ inputs.deployTarget }}

--- a/build/vite/entrypoint.sh
+++ b/build/vite/entrypoint.sh
@@ -4,6 +4,8 @@ set -x
 output=${output:-./release/web}
 baseUrl=${baseUrl:-./}
 
+export VITE_DEPLOY_TARGET=${deployTarget:-web}
+
 mkdir -p $output
 
 bun install

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -41,6 +41,7 @@ runs:
       with:
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
+        deployTarget: "steam"
 
     - name: "Build - Compress Textures"
       uses: "vaguevoid/actions/build/png_compressor@alpha"

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -30,6 +30,8 @@ inputs:
     description: "Steam Depot ID for Linux binaries"
   setLiveBranch:
     description: "A custom Steam branch to set live with this build ('default' not allowed)"
+  pngCompressor:
+    description: "(optional) command line arguments to pass to png_compressor"
 
 runs:
   using: "composite"
@@ -39,6 +41,12 @@ runs:
       with:
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
+
+    - name: "Build - Compress Textures"
+      uses: "vaguevoid/actions/build/png_compressor@alpha"
+      if: ${{ inputs.pngCompressor != '' }}
+      with:
+        args: ${{ inputs.pngCompressor }}
 
     - name: "Package for Windows"
       uses: "vaguevoid/actions/package/electron@alpha"


### PR DESCRIPTION
This PR adds support for running the `png_compressor` as a step in the `share/on/steam` workflow and for setting the environment variable `VITE_DEPLOY_TARGET=steam` when building for steam so that game code can switch to using the optimized `.json/.dxt` textures instead of the `.png` images.

In theory, for Tag Fighter, this will allow us to customize their `share/on/steam` step with the addition of a `pngCompress` argument

```yaml
      - name: Build, Package, and Deploy to Steam
        uses: vaguevoid/actions/share/on/steam@alpha
        with:
          ...
          pngCompress: "-d release/web -i favicon.png character/sword/color psx_circle.png psx_cross.png psx_square.png psx_triangle.png"
```

**NOTE**: we're not (yet) adding it to the `share/on/web` workflow because the size of the images on disk balloons (Tag Fighter from 300MB to almost 4GB) which will make upload and download problematic.

