### PR TITLE
Add (optional) prebuild task

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,3 @@ E.g.
 ```bash
 > docker run -it -e [ENV] -v .:/workspace -w /workspace [IMAGE] [ARGS]
 ```
-
-## TODO
-
-  * publish docker images instead of building them on eveyr action

--- a/build/vite/action.yml
+++ b/build/vite/action.yml
@@ -2,6 +2,9 @@ name: "Void Build Vite"
 author: "Jake Gordon <jake@void.dev>"
 description: "Default web builder for Void games using Vite"
 inputs:
+  prebuild:
+    description: "custom task to run before building the game"
+    required: false
   output:
     description: "output directory for bundled web game"
     default: "release/web"
@@ -16,6 +19,7 @@ runs:
   using: "docker"
   image: "docker://vaguevoid/build-vite:latest"
   env:
+    prebuild: ${{ inputs.prebuild }}
     output: ${{ inputs.output }}
     baseUrl: ${{ inputs.baseUrl }}
     deployTarget: ${{ inputs.deployTarget }}

--- a/build/vite/entrypoint.sh
+++ b/build/vite/entrypoint.sh
@@ -3,10 +3,16 @@ set -x
 
 output=${output:-./release/web}
 baseUrl=${baseUrl:-./}
+prebuild=${prebuild}
 
 export VITE_DEPLOY_TARGET=${deployTarget:-web}
 
 mkdir -p $output
 
 bun install
+
+if [[ ! -z "$prebuild" ]]; then
+  bun run $prebuild
+fi
+
 bun run build --base "${baseUrl}" --outDir "${output}" --emptyOutDir

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: "Build"
       uses: "vaguevoid/actions/build/vite@alpha"
       with:
-        prebuild: ${{ inputes.prebuild }}
+        prebuild: ${{ inputs.prebuild }}
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
         deployTarget: "steam"

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -36,6 +36,9 @@ inputs:
   ignoreTextures:
     description: "(optional) space separated list of images (or directories) to be ignored by texture packer"
     default: "favicon.png"
+  prebuild:
+    description: "custom task to run before building the game"
+    required: false
 
 runs:
   using: "composite"
@@ -43,6 +46,7 @@ runs:
     - name: "Build"
       uses: "vaguevoid/actions/build/vite@alpha"
       with:
+        prebuild: ${{ inputes.prebuild }}
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
         deployTarget: "steam"

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -29,6 +29,9 @@ inputs:
     description: "release folder for build assets"
     required: true
     default: "release"
+  prebuild:
+    description: "custom task to run before building the game"
+    required: false
 
 runs:
   using: "composite"
@@ -36,6 +39,7 @@ runs:
     - name: "Build"
       uses: "vaguevoid/actions/build/vite@alpha"
       with:
+        prebuild: ${{ inputs.prebuild }}
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
 


### PR DESCRIPTION
This PR adds an (optional) `prebuild` input to the `build/vite` (and passed through from `share/on/web` and `share/on/steam`) to allow for a custom task to be run before building the game. This will allow Paul to run his `timestamp` task when building Tag Fighter