### PR TITLE
Update share/on/steam to use new image-compressor

### DIFF
--- a/package/textures/Dockerfile
+++ b/package/textures/Dockerfile
@@ -1,3 +1,3 @@
-FROM vaguevoid/png_compressor:latest
+FROM vaguevoid/image-compressor:latest
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/package/textures/action.yml
+++ b/package/textures/action.yml
@@ -15,6 +15,9 @@ inputs:
   ignore:
     description: "(optional) space separated list of textures (or directories) to be ignored"
     default: "favicon.png"
+  threads:
+    description: "(optional) thread count for image compressor (use 4 for standard GitHub Runner)"
+    default: 4
 runs:
   using: "docker"
   image: "docker://vaguevoid/package-textures:latest"
@@ -22,3 +25,4 @@ runs:
     path: ${{ inputs.path }}
     format: ${{ inputs.format }}
     ignore: ${{ inputs.ignore }}
+    threads: ${{ inputs.threads }}

--- a/package/textures/action.yml
+++ b/package/textures/action.yml
@@ -5,6 +5,13 @@ inputs:
   path:
     description: "path to your bundled web game"
     default: "release/web"
+  format:
+    description: "format for compressed textures (DXT or KTX)"
+    type: choice
+    options:
+     - "DXT"
+     - "KTX"
+    default: "DXT"
   ignore:
     description: "(optional) space separated list of textures (or directories) to be ignored"
     default: "favicon.png"
@@ -13,4 +20,5 @@ runs:
   image: "docker://vaguevoid/package-textures:latest"
   env:
     path: ${{ inputs.path }}
+    format: ${{ inputs.format }}
     ignore: ${{ inputs.ignore }}

--- a/package/textures/entrypoint.sh
+++ b/package/textures/entrypoint.sh
@@ -2,7 +2,8 @@
 
 path=${path:-release/web}
 ignore=${ignore:-favicon.png}
+format=${format:-DXT}
 
 set -x
 
-/usr/local/bin/png_compressor -d ${path} -i ${ignore}
+/usr/local/bin/image_compressor -d ${path} -i ${ignore} --delete-original-images -c ${format}

--- a/package/textures/entrypoint.sh
+++ b/package/textures/entrypoint.sh
@@ -3,7 +3,10 @@
 path=${path:-release/web}
 ignore=${ignore:-favicon.png}
 format=${format:-DXT}
+threads=${threads:-4}
 
 set -x
 
-/usr/local/bin/image_compressor -d ${path} -i ${ignore} --delete-original-images -c ${format}
+date
+/usr/local/bin/image_compressor -d ${path} -i ${ignore} --delete-original-images -c ${format} -t ${threads}
+date

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -43,6 +43,9 @@ inputs:
   ignoreTextures:
     description: "(optional) space separated list of images (or directories) to be ignored by texture packer"
     default: "favicon.png"
+  textureThreads:
+    description: "(optional) thread count for image compressor (use 4 for standard GitHub Runner)"
+    default: 4
   prebuild:
     description: "custom task to run before building the game"
     required: false
@@ -65,6 +68,7 @@ runs:
         path: ${{ inputs.releasePath }}/web
         format: ${{ inputs.textureFormat }}
         ignore: ${{ inputs.ignoreTextures }}
+        threads: ${{ inputs.textureThreads }}
 
     - name: "Package for Windows"
       uses: "vaguevoid/actions/package/electron@alpha"

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -33,6 +33,13 @@ inputs:
   compressTextures:
     description: "true | false to enable texture packing"
     default: "false"
+  textureFormat:
+    description: "format for compressed textures (DXT or KTX)"
+    type: choice
+    options:
+      - "DXT"
+      - "KTX"
+    default: "DXT"
   ignoreTextures:
     description: "(optional) space separated list of images (or directories) to be ignored by texture packer"
     default: "favicon.png"
@@ -56,6 +63,7 @@ runs:
       if: ${{ inputs.compressTextures == 'true' }}
       with:
         path: ${{ inputs.releasePath }}/web
+        format: ${{ inputs.textureFormat }}
         ignore: ${{ inputs.ignoreTextures }}
 
     - name: "Package for Windows"


### PR DESCRIPTION
This PR updates the `share/on/steam` action to use the latest `vaguevoid/image-compressor` and expose the option to generate either `KTX` vs `DXT` textures as well as the `-t threads` option to tune the number of threads so we can limit memory usage to stay within the 16GB of a standard GitHub runner