### PR TITLE
Enable image compressor for the share/on/web action

### DIFF
--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -29,6 +29,22 @@ inputs:
     description: "release folder for build assets"
     required: true
     default: "release"
+  compressTextures:
+    description: "true | false to enable texture packing"
+    default: "false"
+  textureFormat:
+    description: "format for compressed textures (DXT or KTX)"
+    type: choice
+    options:
+      - "DXT"
+      - "KTX"
+    default: "DXT"
+  ignoreTextures:
+    description: "(optional) space separated list of images (or directories) to be ignored by texture packer"
+    default: "favicon.png"
+  textureThreads:
+    description: "(optional) thread count for image compressor (use 4 for standard GitHub Runner)"
+    default: 4
   prebuild:
     description: "custom task to run before building the game"
     required: false
@@ -42,6 +58,16 @@ runs:
         prebuild: ${{ inputs.prebuild }}
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
+        deployTarget: "play.void.dev"
+
+    - name: "Package Textures"
+      uses: "vaguevoid/actions/package/textures@alpha"
+      if: ${{ inputs.compressTextures == 'true' }}
+      with:
+        path: ${{ inputs.releasePath }}/web
+        format: ${{ inputs.textureFormat }}
+        ignore: ${{ inputs.ignoreTextures }}
+        threads: ${{ inputs.textureThreads }}
 
     - name: Get default deploy label
       uses: vaguevoid/actions/deploy/label@alpha


### PR DESCRIPTION
Resolves #17 

This PR enables the `image-compressor` for the `share/on/web` composite action.