### PR TITLE
Allow custom build task name to be used

### DIFF
--- a/build/vite/action.yml
+++ b/build/vite/action.yml
@@ -2,9 +2,10 @@ name: "Void Build Vite"
 author: "Jake Gordon <jake@void.dev>"
 description: "Default web builder for Void games using Vite"
 inputs:
-  prebuild:
-    description: "custom task to run before building the game"
+  taskName:
+    description: "(optional) bun task to build the game"
     required: false
+    default: "build"
   output:
     description: "output directory for bundled web game"
     default: "release/web"
@@ -19,7 +20,7 @@ runs:
   using: "docker"
   image: "docker://vaguevoid/build-vite:latest"
   env:
-    prebuild: ${{ inputs.prebuild }}
+    taskName: ${{ inputs.taskName }}
     output: ${{ inputs.output }}
     baseUrl: ${{ inputs.baseUrl }}
     deployTarget: ${{ inputs.deployTarget }}

--- a/build/vite/entrypoint.sh
+++ b/build/vite/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -x
 
-git config --global --add safe.directory $(pwd) # enable build (or prebuild) to use git binary
+git config --global --add safe.directory $(pwd) # enable build to use git binary
 
+taskName=${taskName:-build}
 output=${output:-./release/web}
 baseUrl=${baseUrl:-./}
-prebuild=${prebuild}
 
 export VITE_DEPLOY_TARGET=${deployTarget:-web}
 
@@ -13,8 +13,4 @@ mkdir -p $output
 
 bun install
 
-if [[ ! -z "$prebuild" ]]; then
-  bun run $prebuild
-fi
-
-bun run build --base "${baseUrl}" --outDir "${output}" --emptyOutDir
+bun run ${taskName} --base "${baseUrl}" --outDir "${output}" --emptyOutDir

--- a/build/vite/readme.md
+++ b/build/vite/readme.md
@@ -4,7 +4,7 @@ This action can be used to build the web version of a Void game using Vite.
 
 Assumptions:
   * Has a `build` script defined inside `package.json`
-  * `build` script uses some combination of `vite build`
+  * `build` script ends with `vite build`
 
 ```yaml
   steps:

--- a/share/on/steam/action.yml
+++ b/share/on/steam/action.yml
@@ -2,6 +2,10 @@ name: "Share a Void game on Steam"
 author: "Jake Gordon <jake@void.dev>"
 description: "Build, Package, and Deploy a Void game to Steam"
 inputs:
+  buildTask:
+    description: "(optional) bun task to build the game"
+    required: false
+    default: "build"
   buildDescription:
     description: "Description for this build"
   executable:
@@ -46,9 +50,6 @@ inputs:
   textureThreads:
     description: "(optional) thread count for image compressor (use 4 for standard GitHub Runner)"
     default: 4
-  prebuild:
-    description: "custom task to run before building the game"
-    required: false
 
 runs:
   using: "composite"
@@ -56,7 +57,7 @@ runs:
     - name: "Build"
       uses: "vaguevoid/actions/build/vite@alpha"
       with:
-        prebuild: ${{ inputs.prebuild }}
+        buildTask: ${{ inputs.buildTask }}
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
         deployTarget: "steam"

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -2,6 +2,10 @@ name: "Share a Void game on the web at play.void.dev"
 author: "Jake Gordon <jake@void.dev>"
 description: "Build, Package, and Deploy a Void game to the Web"
 inputs:
+  buildTask:
+    description: "(optional) bun task to build the game"
+    required: false
+    default: "build"
   host:
     description: "web host url"
     default: "https://play.void.dev/"
@@ -45,9 +49,6 @@ inputs:
   textureThreads:
     description: "(optional) thread count for image compressor (use 4 for standard GitHub Runner)"
     default: 4
-  prebuild:
-    description: "custom task to run before building the game"
-    required: false
 
 runs:
   using: "composite"
@@ -55,7 +56,7 @@ runs:
     - name: "Build"
       uses: "vaguevoid/actions/build/vite@alpha"
       with:
-        prebuild: ${{ inputs.prebuild }}
+        buildTask: ${{ inputs.buildTask }}
         output: ${{ inputs.releasePath }}/web
         baseUrl: ${{ inputs.baseUrl }}
         deployTarget: "play.void.dev"


### PR DESCRIPTION
This PR allows the `taskName` used in the `build/vite` action to be customized (defaults to `build`). Value can be passed through as `buildTask` attribute in both the `share/on/web` and `share/on/steam` composite actions.

Resolved #19 
