### PR TITLE
Add option to pin web deploys on creation

### DIFF
--- a/deploy/web/action.yml
+++ b/deploy/web/action.yml
@@ -25,6 +25,10 @@ inputs:
   password:
     description: "(optional) password protect your shared game"
     required: false
+  pinned:
+    description: "(optional) true | false to pin deploy and prevent auto expiration and deletion"
+    default: "false"
+    required: false
 
 runs:
   using: "docker"
@@ -37,4 +41,5 @@ runs:
     label: ${{ inputs.label }}
     token: ${{ inputs.token }}
     password: ${{ inputs.password }}
+    pinned: ${{ inputs.pinned }}
 

--- a/deploy/web/entrypoint.sh
+++ b/deploy/web/entrypoint.sh
@@ -7,6 +7,7 @@ organization="${organization}"
 game="${game}"
 token="${token}"
 password="${password}"
+pinned="${pinned}"
 endpoint="${host}api/${organization}/${game}/share"
 
 if [[ -z "$host" ]]; then
@@ -43,7 +44,7 @@ tar -czf ${bundle} -C ${path} .
 
 echo "Uploading ${bundle} to ${endpoint}"
 OUTPUT_FILE=$(mktemp)
-STATUS_CODE=$(curl -s -X POST -o $OUTPUT_FILE -w "%{http_code}" --connect-timeout 180 --max-time 180 -H "X-Deploy-Label: ${label}" -H "X-Deploy-Password: ${password}" -H "Authorization: Bearer ${token}" --data-binary "@${bundle}" ${endpoint} 2>/dev/null)
+STATUS_CODE=$(curl -s -X POST -o $OUTPUT_FILE -w "%{http_code}" --connect-timeout 180 --max-time 180 -H "X-Deploy-Label: ${label}" -H "X-Deploy-Password: ${password}" -H "X-Deploy-Pinned: ${pinned}" -H "Authorization: Bearer ${token}" --data-binary "@${bundle}" ${endpoint} 2>/dev/null)
 
 if [[ $STATUS_CODE == "404" ]]; then
   echo "endpoint ${endpoint} not found, are the organization and game correct?"

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -78,7 +78,7 @@ runs:
       id: default_label
 
     - name: "Deploy"
-      uses: "vaguevoid/actions/deploy/web@scarlett/deploy-pinned-option" # TODO: REVERT, for testing purposes
+      uses: "vaguevoid/actions/deploy/web@alpha"
       with:
         path: ${{ inputs.releasePath }}/web
         host: ${{ inputs.host }}

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -28,7 +28,6 @@ inputs:
   pinned:
     description: "(optional) true | false to pin deploy and prevent auto expiration and deletion"
     required: false
-    default: "false"
   baseUrl:
     description: "base URL"
     required: true

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -79,7 +79,7 @@ runs:
       id: default_label
 
     - name: "Deploy"
-      uses: "vaguevoid/actions/deploy/web@alpha"
+      uses: "vaguevoid/actions/deploy/web@scarlett/deploy-pinned-option" # TODO: REVERT, for testing purposes
       with:
         path: ${{ inputs.releasePath }}/web
         host: ${{ inputs.host }}

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -25,6 +25,10 @@ inputs:
   password:
     description: "(optional) password protect your shared game"
     required: false
+  pinned:
+    description: "(optional) true | false to pin deploy and prevent auto expiration and deletion"
+    required: false
+    default: "false"
   baseUrl:
     description: "base URL"
     required: true
@@ -84,3 +88,4 @@ runs:
         label: ${{ inputs.label || steps.default_label.outputs.label }}
         token: ${{ inputs.token }}
         password: ${{ inputs.password }}
+        pinned: ${{ inputs.pinned }}

--- a/share/on/web/action.yml
+++ b/share/on/web/action.yml
@@ -28,6 +28,7 @@ inputs:
   pinned:
     description: "(optional) true | false to pin deploy and prevent auto expiration and deletion"
     required: false
+    default: "false"
   baseUrl:
     description: "base URL"
     required: true


### PR DESCRIPTION
Tested the deploy/web action with a local docker image and server and confirmed that deploys are only set to pinned if the argument is explicitly set to true (deployed the testnopin label both with `pinned="false"` and the pinned argument not being passed to `docker run` at all)


![Screenshot 2024-09-30 at 4 42 40 PM](https://github.com/user-attachments/assets/dd7251d3-8ff5-405a-b920-c13931e0d32e)


![Screenshot 2024-09-30 at 4 43 42 PM](https://github.com/user-attachments/assets/e3d421bf-eaab-4548-a7a8-f191a14c1977)


Depends on https://github.com/vaguevoid/cloud/pull/489