### PR TITLE
Update bun to 1.2.5 in build

### DIFF
--- a/build/vite/Dockerfile
+++ b/build/vite/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:21
-RUN npm install -g bun@1.0.36
+RUN npm install -g bun@1.2.5
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Trying to fix an issue when trying to deploy https://github.com/vaguevoid/halfcadence-piece/actions/runs/13954663770/job/39062653210

`bun install` works locally so we're hoping it might be solved on a newer version